### PR TITLE
fix: allow custom api prefix

### DIFF
--- a/server/utils/middleware.ts
+++ b/server/utils/middleware.ts
@@ -20,7 +20,10 @@ const createFilterMiddleware = (strapi: Strapi) => {
   return async (ctx, next) => {
     if (ctx.request.method !== "GET") return next();
     const url = ctx.request.url;
-    const collectionType = url.replace("/api/", "").split("/")[0].split("?")[0];
+    const collectionType = url
+      .replace(strapi.config.api.rest.prefix, "")
+      .split("/")[0]
+      .split("?")[0];
 
     const model = modelsWithLocation.find(
       (model) => model.collectionName === _.snakeCase(collectionType)


### PR DESCRIPTION
Strapi allows you to use custom api prefix instead of "/api". When this is done the plugin does not work anymore. This PR fixes it.