### PR TITLE
Fix: parse JSON column field

### DIFF
--- a/server/bootstrap.ts
+++ b/server/bootstrap.ts
@@ -39,7 +39,11 @@ export default async ({ strapi }: { strapi: Strapi }) => {
           );
           await Promise.all(
             location.map(async (entry) => {
-              const json = entry[_.snakeCase(locationField)];
+              let json = entry[_.snakeCase(locationField)];
+              // Parse JSON retrieved from Postgres
+              if (typeof json === 'string') {
+                json = JSON.parse(json);
+              }
               if (!json?.lng || !json?.lat) return;
               await db.raw(`
                 UPDATE ${tableName}


### PR DESCRIPTION
During the bootstrap when the location field is retrieved is retrieved from Postgres as string and then after there's if that try to access to JSON parameters using optional chaining. Using optional chaining the statement inside the if will always be false and then it won't repopulate the location geom field