### PR TITLE
fix: unquote variable name when replace is done

### DIFF
--- a/server/utils/middleware.ts
+++ b/server/utils/middleware.ts
@@ -22,8 +22,8 @@ const createFilterMiddleware = (strapi: Strapi) => {
     const url = ctx.request.url;
 
     const collectionType = url
-      .replace("strapi.config.api.rest.prefix", "")
-      .split("/")[0]
+      .replace(strapi.config.api.rest.prefix, "")
+      .split("/")[1]
       .split("?")[0];
 
     const queryString = ctx.request.querystring as string;


### PR DESCRIPTION
Unquote the variable in code and then get the second value because the prefix has leading '/' and the split not work correctly 