### PR TITLE
fix: remove destroy and fix casings

### DIFF
--- a/server/destroy.ts
+++ b/server/destroy.ts
@@ -1,30 +1,3 @@
 import { Strapi } from "@strapi/strapi";
 
-export default async ({ strapi }: { strapi: Strapi }) => {
-  //@ts-expect-error
-  const db = strapi.db.connection;
-
-  const modelsWithLocation =
-    strapi.services[
-      "plugin::location-plugin.locationServices"
-    ].getModelsWithLocation();
-
-  await Promise.all(
-    modelsWithLocation.map(async (model) => {
-      const tableName = model.tableName;
-
-      const locationFields = strapi.services[
-        "plugin::location-plugin.locationServices"
-      ].getLocationFields(model.attributes);
-
-      await Promise.all(
-        locationFields.map(async (locationField) => {
-          await db.raw(`
-            ALTER TABLE ${tableName}
-            DROP COLUMN ${locationField}_geom;
-          `);
-        })
-      );
-    })
-  );
-};
+export default async ({ strapi }: { strapi: Strapi }) => {};

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -18,11 +18,11 @@ const locationServices = ({ strapi }: { strapi: Strapi }) => ({
       .filter(Boolean);
   },
   getModelsWithLocation: () => {
-    // @ts-expect-error
     return strapi.db.config.models
       .filter(
         (model) =>
           (model.uid as string).startsWith("api::") ||
+          //@ts-ignore
           model.modelType === "component" ||
           (model.uid as string) === "plugin::users-permissions.user"
       )

--- a/server/utils/lifecycles.ts
+++ b/server/utils/lifecycles.ts
@@ -1,11 +1,11 @@
 import { Strapi } from "@strapi/strapi";
 import { Event } from "@strapi/database/lib/lifecycles";
 import { Subscriber } from "@strapi/database/lib/lifecycles/subscribers";
+import _ from "lodash";
 
 const locaitonServiceUid = "plugin::location-plugin.locationServices";
 
 const createSubscriber = (strapi: Strapi): Subscriber => {
-  //@ts-expect-error
   const db = strapi.db.connection;
   const modelsWithLocation =
     strapi.services[locaitonServiceUid].getModelsWithLocation();
@@ -31,7 +31,9 @@ const createSubscriber = (strapi: Strapi): Subscriber => {
 
           await db.raw(`
               UPDATE ${model.tableName}
-              SET ${locationField}_geom = ST_SetSRID(ST_MakePoint(${data.lng}, ${data.lat}), 4326)
+              SET ${_.snakeCase(
+                locationField
+              )}_geom = ST_SetSRID(ST_MakePoint(${data.lng}, ${data.lat}), 4326)
               WHERE id = ${id};
           `);
         })
@@ -50,7 +52,9 @@ const createSubscriber = (strapi: Strapi): Subscriber => {
 
           await db.raw(`
             UPDATE ${model.tableName}
-            SET ${locationField}_geom = ST_SetSRID(ST_MakePoint(${data.lng}, ${data.lat}), 4326)
+            SET ${_.snakeCase(locationField)}_geom = ST_SetSRID(ST_MakePoint(${
+            data.lng
+          }, ${data.lat}), 4326)
             WHERE id = ${params.where.id};
           `);
         })

--- a/server/utils/middleware.ts
+++ b/server/utils/middleware.ts
@@ -13,7 +13,6 @@ type LocationQueryCombined = LocationQuery | LogicalQuery;
 
 const locaitonServiceUid = "plugin::location-plugin.locationServices";
 const createFilterMiddleware = (strapi: Strapi) => {
-  //@ts-expect-error
   const db = strapi.db.connection;
   const modelsWithLocation =
     strapi.services[locaitonServiceUid].getModelsWithLocation();
@@ -35,8 +34,8 @@ const createFilterMiddleware = (strapi: Strapi) => {
       model.collectionName === _.snakeCase(collectionType);
     const collectionModel = !isComponentQuery
       ? modelsWithLocation.find((model) => modelCondition(model))
-      : // @ts-expect-error
-        strapi.db.config.models.find(
+      : strapi.db.config.models.find(
+          //@ts-ignore
           (model) => model.collectionName === _.snakeCase(collectionType)
         );
 
@@ -112,7 +111,7 @@ const createFilterMiddleware = (strapi: Strapi) => {
               .whereRaw(
                 `
         ST_DWithin(
-        ${fieldToFilter}_geom,
+        ${_.snakeCase(fieldToFilter)}_geom,
         ST_SetSRID(ST_MakePoint(?, ?), 4326)::geography, ?)`,
                 [lng, lat, range ?? 0]
               )
@@ -130,7 +129,7 @@ const createFilterMiddleware = (strapi: Strapi) => {
                 .whereRaw(
                   `
               ST_DWithin(
-              ${fieldToFilter}_geom,
+              ${_.snakeCase(fieldToFilter)}_geom,
               ST_SetSRID(ST_MakePoint(?, ?), 4326)::geography, ?)`,
                   [lng, lat, range ?? 0]
                 )
@@ -169,7 +168,9 @@ const createFilterMiddleware = (strapi: Strapi) => {
             );
             if (!!locationQueryParams) {
               const [lat, lng, range] = locationQueryParams;
-              return `ST_DWithin(${field}_geom, ST_SetSRID(ST_MakePoint(${lng}, ${lat}), 4326)::geography, ${
+              return `ST_DWithin(${_.snakeCase(
+                field
+              )}_geom, ST_SetSRID(ST_MakePoint(${lng}, ${lat}), 4326)::geography, ${
                 range ?? 0
               })`;
             } else {

--- a/strapi-server.js
+++ b/strapi-server.js
@@ -1,3 +1,3 @@
 "use strict";
 //Change to "./dist/server" while developing
-module.exports = require("./server");
+module.exports = require("./dist/server");

--- a/strapi-server.js
+++ b/strapi-server.js
@@ -1,3 +1,3 @@
 "use strict";
 //Change to "./dist/server" while developing
-module.exports = require("./dist/server");
+module.exports = require("./server");


### PR DESCRIPTION
- Removed redundant ts-ignores because they are not needed with the updated strapi-types library
- removed destroy procedure because it caused problems for larger databases and is not needed
- Unified casings because the bootstrap procedure was again crashing when capital letters were used


Closes #91 