### PR TITLE
fix: bootstrap just update fields, if empty

### DIFF
--- a/server/bootstrap.ts
+++ b/server/bootstrap.ts
@@ -43,7 +43,8 @@ export default async ({ strapi }: { strapi: Strapi }) => {
 
           ), 4326)
           WHERE (${locationField}::json->'lng')::text != 'null' AND
-                (${locationField}::json->'lat')::text != 'null'
+                (${locationField}::json->'lat')::text != 'null' AND
+                ${locationField}_geom::text = 'null';
           `);
         })
       );


### PR DESCRIPTION
This is just an idea, but it reduced the amount of written data dramatically for us. We are using neon DB with DB branches, so every developer for every DB branch has a full database. When you are working on content types, the server will restart frequently, resulting in many GBs of written data per day .. this change would just update the field, when empty. 