### PR TITLE
fix: correctly handling NULL of geom fields

### DIFF
--- a/server/bootstrap.ts
+++ b/server/bootstrap.ts
@@ -44,7 +44,7 @@ export default async ({ strapi }: { strapi: Strapi }) => {
           ), 4326)
           WHERE (${locationFieldSnakeCase}::json->'lng')::text != 'null' AND
                 (${locationFieldSnakeCase}::json->'lat')::text != 'null' AND
-                ${locationFieldSnakeCase}_geom::text = 'null';
+                ${locationFieldSnakeCase}_geom IS NULL;
           `);
         })
       );


### PR DESCRIPTION
After some more testing I realised, that postgres is often not working as expected when trying to cast geom fields to text. With this improvement, the query works better. 