### PR TITLE
fix: moving to native geography fields to prevent type casting

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,12 @@
 /node_modules
 /build
+.circleci/
+.github/
+.nvmrc
+.eslintrc
+codecov.yml
+*.map
+*.spec.*
+setup-package.*
+**/__tests__/**
+**/__mocks__/** 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@notum-cz/strapi-plugin-location",
-  "version": "1.2.6",
+  "name": "@trieb.work/strapi-plugin-location",
+  "version": "1.2.12",
   "description": "This plugin allows users to create location inputs and store latitude and longitude values as geometry types in a PostGIS database. It also provides functionality to filter items based on their location.",
   "keywords": [
     "strapi",
@@ -23,10 +23,10 @@
     "Ondřej Mikulčík <ondrej.mikulcik@notum.cz> (https://notum.cz/en/strapi)"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && tsc -p tsconfig.server.json",
     "clean": "rm -rf build",
     "develop": "NODE_ENV=development tsc -p tsconfig.server.json -w",
-    "prepublish:latest": "npm run clean && npm run build && node build/setup-package.js",
+    "prepublish:latest": "npm run clean && npm run build",
     "publish:latest": "cd build && npm publish --tag latest"
   },
   "dependencies": {

--- a/server/bootstrap.ts
+++ b/server/bootstrap.ts
@@ -31,7 +31,7 @@ export default async ({ strapi }: { strapi: Strapi }) => {
           if (!hasColumn) {
             await db.raw(`
               ALTER TABLE ${tableName}
-              ADD COLUMN ${locationFieldSnakeCase}_geom GEOMETRY(Point, 4326);
+              ADD COLUMN ${locationFieldSnakeCase}_geom GEOGRAPHY(Point, 4326);
             `);
           }
           // Generate point column field using only a query

--- a/server/utils/middleware.ts
+++ b/server/utils/middleware.ts
@@ -112,7 +112,7 @@ const createFilterMiddleware = (strapi: Strapi) => {
                 `
         ST_DWithin(
         ${_.snakeCase(fieldToFilter)}_geom,
-        ST_SetSRID(ST_MakePoint(?, ?), 4326)::geography, ?)`,
+        ST_SetSRID(ST_MakePoint(?, ?), 4326), ?)`,
                 [lng, lat, range ?? 0]
               )
           : null;
@@ -130,7 +130,7 @@ const createFilterMiddleware = (strapi: Strapi) => {
                   `
               ST_DWithin(
               ${_.snakeCase(fieldToFilter)}_geom,
-              ST_SetSRID(ST_MakePoint(?, ?), 4326)::geography, ?)`,
+              ST_SetSRID(ST_MakePoint(?, ?), 4326), ?)`,
                   [lng, lat, range ?? 0]
                 )
             ).map((item) => item.id);
@@ -170,7 +170,7 @@ const createFilterMiddleware = (strapi: Strapi) => {
               const [lat, lng, range] = locationQueryParams;
               return `ST_DWithin(${_.snakeCase(
                 field
-              )}_geom, ST_SetSRID(ST_MakePoint(${lng}, ${lat}), 4326)::geography, ${
+              )}_geom, ST_SetSRID(ST_MakePoint(${lng}, ${lat}), 4326), ${
                 range ?? 0
               })`;
             } else {

--- a/server/utils/middleware.ts
+++ b/server/utils/middleware.ts
@@ -112,7 +112,7 @@ const createFilterMiddleware = (strapi: Strapi) => {
                 `
         ST_DWithin(
         ${_.snakeCase(fieldToFilter)}_geom,
-        ST_SetSRID(ST_MakePoint(?, ?), 4326), ?)`,
+        ST_SetSRID(ST_MakePoint(?, ?), 4326)::geography, ?)`,
                 [lng, lat, range ?? 0]
               )
           : null;
@@ -130,7 +130,7 @@ const createFilterMiddleware = (strapi: Strapi) => {
                   `
               ST_DWithin(
               ${_.snakeCase(fieldToFilter)}_geom,
-              ST_SetSRID(ST_MakePoint(?, ?), 4326), ?)`,
+              ST_SetSRID(ST_MakePoint(?, ?), 4326)::geography, ?)`,
                   [lng, lat, range ?? 0]
                 )
             ).map((item) => item.id);
@@ -170,7 +170,7 @@ const createFilterMiddleware = (strapi: Strapi) => {
               const [lat, lng, range] = locationQueryParams;
               return `ST_DWithin(${_.snakeCase(
                 field
-              )}_geom, ST_SetSRID(ST_MakePoint(${lng}, ${lat}), 4326), ${
+              )}_geom, ST_SetSRID(ST_MakePoint(${lng}, ${lat}), 4326)::geography, ${
                 range ?? 0
               })`;
             } else {

--- a/tsconfig.server.json
+++ b/tsconfig.server.json
@@ -2,7 +2,7 @@
   "extends": "@strapi/typescript-utils/tsconfigs/server",
 
   "compilerOptions": {
-    "outDir": "dist",
+    "outDir": "build/dist",
     "rootDir": "."
   },
 


### PR DESCRIPTION
this PR changes the column type to geography, as we are only working with coordinates and always typecast in all queries. This change allows to create a GIST database index (could be added to this PR or manually by users) to speed up queries dramatically.